### PR TITLE
Fix null update

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -4,6 +4,9 @@ const nls = require('node-localstorage')
 const storage = new nls.LocalStorage('./storage')
 
 const merge = (current, update) => {
+	if (update == null){
+       	    return current;
+   	}
 	Object.keys(update).forEach(key => {
 		// if update[key] exist, and it's not a string or array,
 		// we go in one level deeper


### PR DESCRIPTION
This fixes an error on startup 
```
/Users/sridharavinash/Development/octoterm/storage.js:7
	Object.keys(update).forEach(key => {
	       ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at merge (/Users/sridharavinash/Development/octoterm/storage.js:7:9)
    at Object.getItem (/Users/sridharavinash/Development/octoterm/storage.js:26:10)
    at Object.<anonymous> (/Users/sridharavinash/Development/octoterm/AgendaView.js:4:26)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Module.require (internal/modules/cjs/loader.js:637:17)
```